### PR TITLE
Make the nix code use cache and pin it

### DIFF
--- a/pin.nix
+++ b/pin.nix
@@ -1,0 +1,6 @@
+import (builtins.fetchGit {
+    # Descriptive name to make the store path easier to identify
+    name = "nixos-pin-2022.04.31";
+    url = "https://github.com/nixos/nixpkgs/";
+    rev = "e96c668072d7c98ddf2062f6d2b37f84909a572b";
+    })

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,0 +1,12 @@
+import ./pin.nix {
+  config = {
+
+    packageOverrides = pkgs: {
+        haskell = pkgs.lib.recursiveUpdate pkgs.haskell {
+        packageOverrides = hpNew: hpOld: {
+            agda-search = hpNew.callPackage ./default.nix {};
+            };
+        };
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,7 @@
-{ pkgs ? import <nixpkgs> { }, ... }:
-pkgs.mkShell {
-  packages = [ pkgs.cabal-install ];
-  inputsFrom = [ (pkgs.haskellPackages.callCabal2nix "agda-search" ./. { }).env ];
+{ pkgs ? import ./pkgs.nix, ... }:
+pkgs.haskellPackages.shellFor {
+  packages = ps : [ ps.agda-search ];
+  buildInputs = [
+        pkgs.cabal-install
+        ];
 }


### PR DESCRIPTION
This works locally for me with the cabal file
without changing the dependencies and without having
cabal build any dependencies.

It *should* work on other machines as well.
But this will cause downloading of those libraries in their
respective stores.