### PR TITLE
Move modules into src folder, make it a library, fix warnings.

### DIFF
--- a/agda-search.cabal
+++ b/agda-search.cabal
@@ -6,10 +6,26 @@ maintainer:         me@amelia.how
 
 extra-source-files: CHANGELOG.md
 
+library
+  exposed-modules:    AgdaSearch.Schema
+                    , AgdaSearch.Populate
+                    , AgdaSearch.Cli
+  ghc-options: -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints -Wincomplete-record-updates -Widentities -Wcpp-undef -fwarn-tabs -Wpartial-fields -fdefer-diagnostics
+  default-language: Haskell2010
+  build-depends:    base            ^>=4.14.3.0
+                    , Agda            == 2.6.2
+                    , text            == 1.2.*
+                    , containers      == 0.6.5.*
+                    , vector          == 0.12.*
+                    , alfred-margaret ^>= 1.1.0.0
+                    , hashable
+                    , syb
+                    , deepseq
+                    , sqlite-simple
+  hs-source-dirs:   src
+
 executable agda-search
     main-is:          Main.hs
-    other-modules:    Schema
-                    , Populate
     build-depends:    base            ^>=4.14.3.0
                     , Agda            == 2.6.2
                     , text            == 1.2.*
@@ -20,5 +36,6 @@ executable agda-search
                     , syb
                     , deepseq
                     , sqlite-simple
+                    , agda-search
     hs-source-dirs:   app
     default-language: Haskell2010

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,51 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Main where
 
-import Control.Monad
-import Control.Monad.IO.Class
-import Data.Foldable
-import qualified Data.Text as Text
-import qualified Data.Text.AhoCorasick.Automaton as Aho
-import Data.Text.AhoCorasick.Searcher (automaton, needles)
-import qualified Data.Text.IO as Text
-import Database.SQLite.Simple
-import Populate
-import Schema
-import System.Environment
+import qualified AgdaSearch.Cli as Cli
 
 main :: IO ()
-main = do
-  [basepath, main, database] <- getArgs
-
-  withConnection database $ \conn -> do
-    createDb conn
-    [Only count] <- query_ conn "select count(*) from identifiers"
-
-    when (count == (0 :: Int)) $ do
-      putStrLn "Loading types..."
-      runAgda basepath $ do
-        iss <- findInScopeSet main
-
-        liftIO . putStrLn $ "Type checked! Populating database..."
-        traverse_ (insertIdentifier conn) iss
-
-    putStrLn "Loaded types!"
-    putStr "\27[2J\27[H"
-    forever $ do
-      putStr "> "
-      queryStr <- getLine
-
-      sl <-
-        query
-          conn
-          "select * from identifiers where name like ?"
-          (Only (Text.singleton '%' <> Text.pack queryStr <> Text.singleton '%'))
-
-      let showit Identifier {name = name, typestr = typestr, fileref = fileref, byteoffset = bo} = do
-            [Only modname] <-
-              query conn "select modname from filemod where fileid = ?" (Only fileref)
-            let url = "https://1lab.dev/" <> modname <> ".html#" <> Text.pack (show bo)
-            pure $ name <> " : " <> typestr <> "\nDefined at: " <> url
-
-      traverse_ (Text.putStrLn <=< showit) sl
+main = Cli.main

--- a/src/AgdaSearch/Cli.hs
+++ b/src/AgdaSearch/Cli.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module AgdaSearch.Cli where
+
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Foldable
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Database.SQLite.Simple
+import AgdaSearch.Populate
+import AgdaSearch.Schema
+import System.Environment
+
+-- | cabal run agda-search -- ../agda ../agda/src/main/Main.hs x.db
+--
+--  to create the all.agda file:
+--  download std-lib
+--  run:
+--
+--  @
+-- std-lib/src on  HEAD (b85c5d1)
+-- ❯ fd ".*agda" . > All.agda
+--  @
+--
+--  then open in vim.
+--  :%s/[a-z]/import &/g
+--  :%s/\.agda//g
+--  :%s/\///g
+main :: IO ()
+main = do
+  [basepath, main', database] <- getArgs
+
+  withConnection database $ \conn -> do
+    createDb conn
+    [Only count] <- query_ conn "select count(*) from identifiers"
+
+    when (count == (0 :: Int)) $ do
+      putStrLn "Loading types..."
+      runAgda basepath $ do
+        iss <- findInScopeSet main'
+
+        liftIO . putStrLn $ "Type checked! Populating database..."
+        traverse_ (insertIdentifier conn) iss
+
+    putStrLn "Loaded types!"
+    putStr "\27[2J\27[H"
+    forever $ do
+      putStr "> "
+      queryStr <- getLine
+
+      sl <-
+        query
+          conn
+          "select * from identifiers where name like ?"
+          (Only (Text.singleton '%' <> Text.pack queryStr <> Text.singleton '%'))
+
+      let showit Identifier {name = name', typestr = typestr', fileref = fileref', byteoffset = bo} = do
+            [Only modname'] <-
+              query conn "select modname from filemod where fileid = ?" (Only fileref')
+            let url = "https://1lab.dev/" <> modname' <> ".html#" <> Text.pack (show bo)
+            pure $ name' <> " : " <> typestr' <> "\nDefined at: " <> url
+
+      traverse_ (Text.putStrLn <=< showit) sl

--- a/src/AgdaSearch/Schema.hs
+++ b/src/AgdaSearch/Schema.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Schema where
+module AgdaSearch.Schema where
 
 import Data.Text (Text)
 import Database.SQLite.Simple


### PR DESCRIPTION
Also make it more eager to compile whatever is thrown at it.
I'm not sure if the intention was to use this for
1lab, but for the standard library I had to enable a bunch
of flag (gaurdedness for example).